### PR TITLE
Circle installs fixed, correct version of bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             chmod +x ./cc-test-reporter
 
       # Bundle install dependencies
-      - run: gem install bundler --no-document
+      - run: gem install bundler --no-document -v 1.12.0
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - run: bundle clean --force
 


### PR DESCRIPTION
## What did we change?

* Install `bundler` gem version `1.12.0` as specified in the dev dependencies instead of the latest version.

## Why are we doing this?

This works around bugs/errors in compatibility with the recently released bundler 2.x.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
